### PR TITLE
Search for config file in system dirs as fallback

### DIFF
--- a/hilbifetch.lua
+++ b/hilbifetch.lua
@@ -100,6 +100,9 @@ local ok = pcall(function()
 	dofile (os.getenv 'HOME' .. '/.config/hilbifetch/hfconf.lua')
 end)
 if not ok then
+	ok = pcall(function() dofile '/etc/hfconf.lua' end)
+end
+if not ok then
 	pcall(function() dofile 'hfconf.lua' end)
 end
 


### PR DESCRIPTION
Full disclosure: I have absolutely zero Lua experience, but I figured this would be a good addition for packaged installations. Since most package scripts (at least PKGBUILDs) can't write to a user's home directory during installation, this seems like a sensible default to fall back to.